### PR TITLE
Major refactor of command handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /gh-dependency-report
 /gh-dependency-report.exe
+*.csv
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,vim,go
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,macos,vim,go

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,14 +94,18 @@ func stubbedDependencies() dependenciesQuery {
 
 func TestCommand(t *testing.T) {
 	cases := []struct {
-		name    string
-		args    []string
-		stubs   func(g *testGetter)
-		wantOut func(t *testing.T, output *bytes.Buffer)
+		name         string
+		owner        string
+		repos        []string
+		repoExcludes []string
+		stubs        func(g *testGetter)
+		wantOut      func(t *testing.T, output *bytes.Buffer)
 	}{
 		{
-			name: "example test",
-			args: []string{"OWNER"},
+			name:         "example test",
+			owner:        "OWNER",
+			repos:        []string{},
+			repoExcludes: []string{},
 			stubs: func(g *testGetter) {
 				g.Stub("GetRepos", stubbedRepoList("REPO"))
 				g.Stub("GetManifests", stubbedManifests())
@@ -123,7 +127,7 @@ func TestCommand(t *testing.T) {
 				tt.stubs(client)
 			}
 
-			err := runCmd(tt.args, client, out)
+			err := runCmd(tt.owner, tt.repos, tt.repoExcludes, client, out)
 			if err != nil {
 				t.Errorf("Did not expect error; got %s", err.Error())
 			}

--- a/main.go
+++ b/main.go
@@ -4,8 +4,24 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 */
 package main
 
-import "github.com/andyfeller/gh-dependency-report/cmd"
+import (
+	"os"
+
+	"github.com/andyfeller/gh-dependency-report/cmd"
+	"go.uber.org/zap"
+)
 
 func main() {
-	cmd.Execute()
+
+	// Initlaize global logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+	zap.ReplaceGlobals(logger)
+
+	// Instantiate and execute root command
+	cmd := cmd.NewCmd()
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
These changes were being based on advice from @mislav for isolating the spf13/cobra and uber/zap logic from the core of the cli logic.

Now, the application should be easier to build better tests, being able to inject mocks appropriately as well as allowing for tests to run without blowing up due to log initialization problems.  That aspect is going to need more work, however, as I want to have a better default logging configuraiton with flags to override levels.